### PR TITLE
Copyedit readme following Fivetran docs style

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ or open PRs against `master`. Check out
 on the best workflow for contributing to a package.
 
 ## Resources:
+- Find all of Fivetran's pre-built dbt packages in our [dbt hub](https://hub.getdbt.com/fivetran/)
 - Provide [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next
 - Learn more about Fivetran [here](https://fivetran.com/docs)
 - Check out [Fivetran's blog](https://fivetran.com/blog)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Bing Ads (Source)
+# Microsoft Advertising (Source)
 
-This package models Bing Ads data from [Fivetran's connector](https://fivetran.com/docs/applications/microsoft-advertising). It uses data in the format described by [this ERD](https://docs.google.com/presentation/d/1xNeRCtU5dNVy01kTjE-ydX_BLoRDgKZOHGci1vUKDFg/edit).
+This package models Microsoft Advertising data from [Fivetran's connector](https://fivetran.com/docs/applications/microsoft-advertising). It uses data in the format described by [this ERD](https://docs.google.com/presentation/d/1xNeRCtU5dNVy01kTjE-ydX_BLoRDgKZOHGci1vUKDFg/edit).
 
 This package enriches your Fivetran data by doing the following:
 
@@ -10,18 +10,16 @@ This package enriches your Fivetran data by doing the following:
 
 ## Models
 
-This package contains staging models, designed to work simultaneously with our [Bing Ads modeling package](https://github.com/fivetran/dbt_bing_ads). The staging models:
-
-* Name columns consistently across all packages:
-* Boolean fields are prefixed with is_ or has_
-* Timestamps are appended with _at
-* ID primary keys are prefixed with the name of the table. For example, the campaign table's ID column is renamed campaign_id.
+This package contains staging models, designed to work simultaneously with our [Microsoft Advertising modeling package](https://github.com/fivetran/dbt_microsoft_ads). The staging models name columns consistently across all packages:
+* Boolean fields are prefixed with `is_` or `has_`
+* Timestamps are appended with `_at`
+* ID primary keys are prefixed with the name of the table. For example, the campaign table's ID column is renamed `campaign_id`.
 
 ## Installation Instructions
 Check [dbt Hub](https://hub.getdbt.com/) for the latest installation instructions, or [read the dbt docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.
 
 ## Configuration
-By default this package will look for your Bing Ads data in the `bing_ads` schema of your [target database](https://docs.getdbt.com/docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile). If this is not where your Bing Ads data is, please add the following configuration to your `dbt_project.yml` file:
+By default, this package looks for your Microsoft Advertising data in the `bing_ads` schema of your [target database](https://docs.getdbt.com/docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile). If this is not where your Microsoft Advertising data is, add the following configuration to your `dbt_project.yml` file:
 
 ```yml
 # dbt_project.yml


### PR DESCRIPTION
Part of https://github.com/fivetran/engineering/issues/80441

Fix grammar and spelling problems. Fix formatting issues. Replace deprecated name "Bing Ads" with "Microsoft Advertising."

I've left additional explanations about my edits inline.

**We need to replace "Bing Ads" everywhere else too.** Kristin confirmed that she will work on this via Slack.